### PR TITLE
Upgrade to kinesis-readable@1.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "no-console": [0],
+    "semi": [2, "always"]
+  },
+  "env": {
+      "node": true
+  },
+  "globals": {
+      "process": true,
+      "module": true,
+      "require": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
     "preset": "airbnb"
   },
   "devDependencies": {
+    "eslint": "^1.10.3",
     "jscs": "^1.12.0",
     "jshint": "^2.6.3",
     "tape": "^4.0.0"
   },
   "dependencies": {
     "aws-sdk": "^2.1.20",
-    "kinesalite": "^1.4.1",
-    "kinesis-readable": "0.2.1",
+    "kinesalite": "^1.10.1",
+    "kinesis-readable": "^1.0.0",
     "queue-async": "^1.0.7",
     "underscore": "^1.8.2"
   }

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Creates a kinesis stream for you to test against.
 
 **kinesis.shards**
 
-Once your stream is created, `shards` will provide you an array of [kinesis-readable](https://github.com/rclark/kinesis-readable) streams, one for each shard.
+Once your stream is created, `shards` will provide you an array of functions, one for each shard. Pass an `options` object to this function in order to create a [kinesis-readable](https://github.com/rclark/kinesis-readable) streams.
 
 **kinesis.load(fixtures)**
 


### PR DESCRIPTION
Changes `.shards` from an array of pre-built [kinesis-readable](https://github.com/rclark/kinesis-readable) streams into _functions_. Provide the function with an options object in order to return a kinesis-readable stream. 

Also cleans up some logic surrounding stream deletion.
